### PR TITLE
Fix: lido-ui useSystemTheme hook breaking change

### DIFF
--- a/providers/theme.tsx
+++ b/providers/theme.tsx
@@ -48,7 +48,11 @@ const ThemeProvider: FC = ({ children }) => {
   const [themeName, setThemeName] = useState<ThemeName>(DEFAULT_THEME);
 
   useEffect(() => {
-    setThemeName(themeLS ?? systemTheme);
+    if (themeLS) {
+      setThemeName(themeLS);
+    } else if (systemTheme) {
+      setThemeName(systemTheme);
+    }
   }, [themeLS, systemTheme]);
 
   // remember the theme on manual toggle, ignore system theme changes


### PR DESCRIPTION
## Description

Adds a check that useSystemTheme actually returned a value for system theme.

## Related Issue

Closes #40 

## How Has This Been Tested?

Tested that this condition works before and after lido-ui upgrade.

## Checklist

- [ ] Requires other services change
- [ ] Affects to other services
- [ ] Requires dependency update
- [ ] Automated tests
- [ ] Looks good on large screens
- [ ] Looks good on mobile
