### PR TITLE
Added codeowners for lockfiles

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 **/yarn.lock @jabher @kozlovzxc
 **/yarn.lock @jabher @kozlovzxc
+**/yarn.lock @jabher @kozlovzxc

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 **/yarn.lock @jabher @kozlovzxc
 **/yarn.lock @jabher @kozlovzxc
 **/yarn.lock @jabher @kozlovzxc
+**/yarn.lock @jabher @kozlovzxc

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+**/yarn.lock @jabher @kozlovzxc

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 **/yarn.lock @jabher @kozlovzxc
+**/yarn.lock @jabher @kozlovzxc


### PR DESCRIPTION
## Description

Most of the information can be found in [this policy](https://www.notion.so/NPM-package-management-policy-4b577937b07943f58d65f9f1d95b518f).

Basically, we are trying to enforce an update-freeze policy for a month. Updating any package may expose our development and production environments to possible attacks from political activists, so we want to be notified if there are any updates in these files.

## How Has This Been Tested?

I've tested this codeowners file in this repo - https://github.com/kozlovzxc/codeowners-test. 

- Here is the test for lockfile in root folder - https://github.com/kozlovzxc/codeowners-test/pull/1.
- Here is the test for lockfile in subfolder - https://github.com/kozlovzxc/codeowners-test/pull/2
