### PR TITLE
Fix: save memory by streaming responses

### DIFF
--- a/pages/api/rpc.ts
+++ b/pages/api/rpc.ts
@@ -38,9 +38,11 @@ const rpc: Rpc = async (req, res) => {
       body: JSON.stringify(req.body),
     });
 
-    const responded = await requested.json();
-
-    res.status(requested.status).json(responded);
+    res.setHeader(
+      'Content-Type',
+      requested.headers.get('Content-Type') ?? 'application/json',
+    );
+    res.status(requested.status).send(requested.body);
   } catch (error) {
     serverLogger.error(error);
     if (error instanceof Error) {


### PR DESCRIPTION
# Overview

When we read all data and then convert it to JSON, we need to store the response in memory first and then parse it, which may require a noticeable amount of memory depending on the payload size.

```typescript
 const responded = await requested.json();
 res.status(requested.status).json(responded);
```

On the other hand, if we don't actually need the final object on server side, we can just proxy the request as a stream.

```typescript
res.status(requested.status).send(requested.body);
```

In this case, we just need to set the correct content-type header.

```typescript
    res.setHeader(
      'Content-Type',
      requested.headers.get('Content-Type') ?? 'application/json',
    );
```

Btw, `headers.get` may return null, if this header is omitted in the response, so we need to just add `application/json` in that case.