### PR TITLE
Don't publish template on stage

### DIFF
--- a/.github/workflows/ci-staging.yml
+++ b/.github/workflows/ci-staging.yml
@@ -11,12 +11,9 @@ on:
 permissions: {}
 
 jobs:
-  # test:
-  #   ...
-
   deploy:
+    if: ${{ github.repository != 'lidofinance/lido-frontend-template' }}
     runs-on: ubuntu-latest
-    # needs: test
     name: Build and deploy
     steps:
       - name: Staging deploy


### PR DESCRIPTION
# Description

There is no stage for template, so we should disable it, so our checks doesn't spam with failed CI run

<img width="828" alt="image" src="https://user-images.githubusercontent.com/103929444/206214962-5efa8fbb-36a3-445b-a173-29d452f81977.png">