### PR TITLE
dockerfile update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:24-alpine AS build
 
 WORKDIR /app
 
-RUN apk add --no-cache git=2.36.3-r0
+RUN apk add --no-cache git=2.53.0-r0
 COPY package.json yarn.lock ./
 
 RUN yarn install --frozen-lockfile --non-interactive --ignore-scripts \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,6 @@ USER node
 EXPOSE 3000
 
 HEALTHCHECK --interval=10s --timeout=3s \
-  CMD wget -q -O /dev/null http://127.0.0.1:3000/api/health || exit 1
+  CMD wget -q -O /dev/null http://localhost:3000/api/health || exit 1
 
 CMD ["yarn", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM node:24-alpine AS build
 
 WORKDIR /app
 
-# hadolint ignore=DL3018
-RUN apk add --no-cache git
+RUN apk add --no-cache git=2.36.3-r0
 COPY package.json yarn.lock ./
 
 RUN yarn install --frozen-lockfile --non-interactive --ignore-scripts \
@@ -35,7 +34,7 @@ COPY --from=build /app /app
 USER node
 EXPOSE 3000
 
-HEALTHCHECK --interval=10s --timeout=3s \
+HEALTHCHECK --interval=10s --timeout=3s --start-period=30s \
   CMD wget -q -O /dev/null http://127.0.0.1:3000/api/health || exit 1
 
 CMD ["yarn", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,6 @@ USER node
 EXPOSE 3000
 
 HEALTHCHECK --interval=10s --timeout=3s \
-  CMD wget -q -O /dev/null http://localhost:3000/api/health || exit 1
+  CMD wget -q -O /dev/null http://127.0.0.1:3000/api/health || exit 1
 
 CMD ["yarn", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN NODE_NO_BUILD_DYNAMICS=true yarn typechain && yarn build
 # public/runtime is used to inject runtime vars; it should exist and user node should have write access there for it
 RUN rm -rf /app/public/runtime \
   && mkdir -p /app/public/runtime \
-  && chown node:node /app/public/runtime
+  && chown node /app/public/runtime
 
 # final image
 FROM node:24-alpine AS base

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY --from=build /app /app
 USER node
 EXPOSE 3000
 
-HEALTHCHECK --interval=10s --timeout=3s --start-period=15s --retries=3 \
+HEALTHCHECK --interval=10s --timeout=3s \
   CMD wget -q -O /dev/null http://127.0.0.1:3000/api/health || exit 1
 
 CMD ["yarn", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:24-alpine AS build
 
 WORKDIR /app
 
-RUN apk add --no-cache git=2.53.0-r0
+RUN apk add --no-cache git=2.52.0-r0
 COPY package.json yarn.lock ./
 
 RUN yarn install --frozen-lockfile --non-interactive --ignore-scripts \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN NODE_NO_BUILD_DYNAMICS=true yarn typechain && yarn build
 # public/runtime is used to inject runtime vars; it should exist and user node should have write access there for it
 RUN rm -rf /app/public/runtime \
   && mkdir -p /app/public/runtime \
-  && chown -R node:node /app/public/runtime
+  && chown node:node /app/public/runtime
 
 # final image
 FROM node:24-alpine AS base

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,24 @@
 # build env
-FROM node:16-alpine as build
+FROM node:24-alpine AS build
 
 WORKDIR /app
 
-RUN apk add --no-cache git=2.36.3-r0
+# hadolint ignore=DL3018
+RUN apk add --no-cache git
 COPY package.json yarn.lock ./
 
-RUN yarn install --frozen-lockfile --non-interactive --ignore-scripts && yarn cache clean
+RUN yarn install --frozen-lockfile --non-interactive --ignore-scripts \
+  && yarn cache clean
 
 COPY . .
 RUN NODE_NO_BUILD_DYNAMICS=true yarn typechain && yarn build
 # public/runtime is used to inject runtime vars; it should exist and user node should have write access there for it
-RUN rm -rf /app/public/runtime && mkdir /app/public/runtime && chown node /app/public/runtime
+RUN rm -rf /app/public/runtime \
+  && mkdir -p /app/public/runtime \
+  && chown -R node:node /app/public/runtime
 
 # final image
-FROM node:16-alpine as base
+FROM node:24-alpine AS base
 
 ARG BASE_PATH=""
 ARG SUPPORTED_CHAINS="1"
@@ -26,13 +30,12 @@ ENV NEXT_TELEMETRY_DISABLED=1 \
   DEFAULT_CHAIN=$DEFAULT_CHAIN
 
 WORKDIR /app
-RUN apk add --no-cache curl=7.83.1-r4
 COPY --from=build /app /app
 
 USER node
 EXPOSE 3000
 
-HEALTHCHECK --interval=10s --timeout=3s \
-  CMD curl -f http://localhost:3000/api/health || exit 1
+HEALTHCHECK --interval=10s --timeout=3s --start-period=15s --retries=3 \
+  CMD wget -q -O /dev/null http://127.0.0.1:3000/api/health || exit 1
 
 CMD ["yarn", "start"]


### PR DESCRIPTION
## Description

[SRE-3653](https://linear.app/lidofi/issue/SRE-3653)
Dockerfile updated, main things:

- base image switched to node:24-alpine
- updated git version
- switched healthcheck from curl to wget
- syntax/linters adjustments

```
$ docker build .
[+] Building 107.9s (15/15) FINISHED                                                           docker:default
 => [internal] load build definition from Dockerfile                                                     0.0s
 => => transferring dockerfile: 1.01kB                                                                   0.0s
 => [internal] load metadata for docker.io/library/node:24-alpine                                        2.5s
 => [auth] library/node:pull token for registry-1.docker.io                                              0.0s
 => [internal] load .dockerignore                                                                        0.0s
 => => transferring context: 489B                                                                        0.0s
 => [internal] load build context                                                                        0.0s
 => => transferring context: 546.44kB                                                                    0.0s
 => [build 1/8] FROM docker.io/library/node:24-alpine@sha256:7fddd9ddeae8196abf4a3ef2de34e11f7b1a722119  7.4s
 => => resolve docker.io/library/node:24-alpine@sha256:7fddd9ddeae8196abf4a3ef2de34e11f7b1a722119f91f28  0.0s
 => => sha256:589002ba0eaed121a1dbf42f6648f29e5be55d5c8a6ee0f8eaa0285cc21ac153 3.86MB / 3.86MB           3.3s
 => => sha256:d8573c1c310e7789794576ea96c600be3bb905a6cf0ef787f89922d992d39b78 51.11MB / 51.11MB         6.7s
 => => sha256:0653b96c7e89eb8a796a819757fa29a918692669e68f09eac2215c6401407538 1.26MB / 1.26MB           2.6s
 => => sha256:7fddd9ddeae8196abf4a3ef2de34e11f7b1a722119f91f28ddf1e99dcafdf114 3.87kB / 3.87kB           0.0s
 => => sha256:e9445c64ace1a9b5cdc60fc98dd82d1e5142985d902f41c2407e8fffe49d46a3 1.72kB / 1.72kB           0.0s
 => => sha256:3d11569681e47fd750815cb990de3b4ce8c63299924f6bc62d656bfee21501e2 6.52kB / 6.52kB           0.0s
 => => sha256:867a770c9b3548b3b2357b54112add9711dd53d8679a3c1bb4c3d9ac675a5c02 448B / 448B               3.4s
 => => extracting sha256:589002ba0eaed121a1dbf42f6648f29e5be55d5c8a6ee0f8eaa0285cc21ac153                0.1s
 => => extracting sha256:d8573c1c310e7789794576ea96c600be3bb905a6cf0ef787f89922d992d39b78                0.6s
 => => extracting sha256:0653b96c7e89eb8a796a819757fa29a918692669e68f09eac2215c6401407538                0.0s
 => => extracting sha256:867a770c9b3548b3b2357b54112add9711dd53d8679a3c1bb4c3d9ac675a5c02                0.0s
 => [build 2/8] WORKDIR /app                                                                             0.1s
 => [build 3/8] RUN apk add --no-cache git=2.52.0-r0                                                     6.8s
 => [build 4/8] COPY package.json yarn.lock ./                                                           0.0s 
 => [build 5/8] RUN yarn install --frozen-lockfile --non-interactive --ignore-scripts   && yarn cache   64.4s 
 => [build 6/8] COPY . .                                                                                 0.0s 
 => [build 7/8] RUN NODE_NO_BUILD_DYNAMICS=true yarn typechain && yarn build                            20.3s 
 => [build 8/8] RUN rm -rf /app/public/runtime   && mkdir -p /app/public/runtime   && chown node /app/p  0.2s 
 => [base 3/3] COPY --from=build /app /app                                                               2.4s 
 => exporting to image                                                                                   2.1s 
 => => exporting layers                                                                                  2.1s 
 => => writing image sha256:f3d241a2ea27a0ee91090879b74249ca6b6be82789ecf43cf0bf452136a048f3             0.0s
```
```
$ docker run --rm -p 3000:3000 f3d241a2ea27
yarn run v1.22.22
$ NODE_OPTIONS='-r next-logger' next start
Loaded env from /app/.env
{"level":"info","time":1773820572204,"pid":28,"hostname":"23f501f495f3","name":"next.js","prefix":"ready","msg":"started server on *******:3000, url: http://localhost:3000"}
{"level":"info","time":1773820572281,"pid":28,"hostname":"23f501f495f3","name":"console","msg":"created runtime files"}
```
```
$ docker ps
CONTAINER ID   IMAGE          COMMAND                  CREATED          STATUS                    PORTS                                       NAMES
23f501f495f3   f3d241a2ea27   "docker-entrypoint.s…"   11 seconds ago   Up 10 seconds (healthy)   0.0.0.0:3000->3000/tcp, :::3000->3000/tcp   fervent_goldstine
```